### PR TITLE
python setup.py install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ python:
 # command to install dependencies
 install:
   - pip install -U pip wheel
-  - pip install scipy
   - pip install sphinx
-  - pip -v install -e .
+  - python setup.py install
   - python -m nltk.downloader wordnet
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,20 @@
 from setuptools import setup, find_packages
 from os import path
 from codecs import open
+import pip
 
 current_path = path.abspath(path.dirname(__file__))
+
+#install numpy and scipy if not exists seperately since compiled header are required
+try:
+	import numpy
+except ImportError:
+	pip.main(['install','numpy'])
+
+try:
+	import scipy
+except ImportError:
+	pip.main(['install','scipy'])
 
 try:
     import pypandoc
@@ -23,32 +35,39 @@ setup(
     include_package_data=True,
     keywords='IRC parser data-analysis research development',
     packages=find_packages(exclude=['docs', 'tests']),
+    
+    setup_requires=[
+    	'graphviz'
+    ],
 
     install_requires=[
-        'scipy',
-        'numpy',
         'networkx',
         'matplotlib',
         'pygraphviz',
         'scikit-learn',
         'pandas',
         'python-igraph',
-        'sphinx',
-        'pyyaml',
-        't3SphinxThemeRtd',
-        't3fieldlisttable',
-        't3tablerows',
-        't3targets',
-        'sphinxcontrib-googlechart',
-        'sphinxcontrib-googlemaps',
-        'sphinxcontrib-httpdomain',
-        'sphinxcontrib-slide',
-        'sphinxcontrib.youtube',
         'nltk',
         'plotly',
         'ddt',
-        'codeclimate-test-reporter',
-        'memory_profiler',
-        'snakefood'
     ],
+    extra_requires={
+    	'dev': [
+    		'sphinx',
+        	'pyyaml',
+        	'sphinx_rtd_theme>=0.2.4',
+        	't3fieldlisttable',
+        	't3tablerows',
+        	't3targets',
+        	'sphinxcontrib-googlechart',
+        	'sphinxcontrib-googlemaps',
+        	'sphinxcontrib-httpdomain',
+        	'sphinxcontrib-slide',
+        	'sphinxcontrib.youtube',
+        	'codeclimate-test-reporter',
+        	'memory_profiler',
+        	'snakefood'
+    	]
+    }
+        
 )


### PR DESCRIPTION
## What? Why?
Fix # . (Add Reference to the issue if any) fix setup.py. now install can be done using simple python setup.py install

Changes proposed in this pull request:
-  install numy and scipy in beginning if they don't exist

## Checks
- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure you have added required documentation
- [ ] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96