### PR TITLE
setup.py: force networkx 1.11 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
 
     install_requires=[
-        'networkx',
+        'networkx==1.11',
         'matplotlib',
         'pygraphviz',
         'scikit-learn',


### PR DESCRIPTION
Since the library was written with networkx
version 1.11, some of the tests in travis fails
because no version of networkx is mentioned in
setup.py and hence by default it installs latest.
This patch forces 1.11 version install.

## What? Why?
Fix # .Since travis installs the latest nx version but networkx has added new functionality and changes that is not compatible with our code currently. So this patch forces the nx version 1.11

Changes proposed in this pull request:
- a force nx version 1.11

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96