### PR TITLE
in_out saver.py: use QUOTE_NONNUMERIC in save_csv

### DIFF
--- a/lib/in_out/saver.py
+++ b/lib/in_out/saver.py
@@ -90,6 +90,6 @@ def save_csv(matrix, output_directory, output_file_name):
     check_if_dir_exists(output_directory) #create output directory if doesn't exist
     output_file = output_directory + "/" + output_file_name +".csv"
     with open(output_file, 'wb') as myfile:
-        wr = csv.writer(myfile, quoting=csv.QUOTE_ALL)
+        wr = csv.writer(myfile, quoting=csv.QUOTE_NONNUMERIC)
         for col in matrix:
             wr.writerow(col)


### PR DESCRIPTION
The save_csv function should quote only non numbers,
since quoting numbers causes a problem when we wish
to read the csv again. eg. the heatmap plot function
in vis.py is affected.

Issue link: https://github.com/prasadtalasila/IRCLogParser/issues/90

## What? Why?
Fix # . #90 

Changes proposed in this pull request:
- a Quote only non numerics while saving data to csv

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96