### PR TITLE
vis.py: return curve fir parameter for calc_plot_linear_fit

### DIFF
--- a/lib/vis.py
+++ b/lib/vis.py
@@ -239,8 +239,9 @@ def generate_log_plots(filter_val, plot_data, output_directory, output_file_name
     x_axis_log = [math.log(i) for i in xrange(1, filter_val)]   # ignore degree 0
     y_axis_log = [math.log(i) if i>0 else 0 for i in sum_each_row[1:filter_val] ]   # ignore degree 01
 
-    calc_plot_linear_fit(x_axis_log, y_axis_log, output_file_name, output_directory)
-
+    slope,intercept,r_square,mean_squared_error = calc_plot_linear_fit(x_axis_log, y_axis_log, output_directory, output_file_name)
+    
+    return slope,intercept,r_square,mean_squared_error
 
 def calc_plot_linear_fit(x_in, y_in, output_directory, output_file_name):
     """
@@ -306,6 +307,8 @@ def calc_plot_linear_fit(x_in, y_in, output_directory, output_file_name):
         plt.legend(['Data', 'Fit'], loc='upper right')
         plt.savefig(output_directory+"/" + output_file_name+".png")
         plt.close()
+        
+    return slope,intercept,r_value**2,mean_squared_error(y, line)
 
 
 def generate_group_bar_charts(y_values, x_values, trace_header, output_directory, output_file_name):


### PR DESCRIPTION
We need to save the linear fit parameters for log plots,
but currently these parameters are just printed on terminal
and not returned by the fir function so that they may be
saved in a csv. This patch adds a return statement returning
the fit parameters.

Issue link: https://github.com/prasadtalasila/IRCLogParser/issues/96

Changes proposed in this pull request:
- a return fit parameters from cal_plot_linear_fit

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96