### PR TITLE
analysis: fix generation of reduced presence graphs

### DIFF
--- a/lib/analysis/community.py
+++ b/lib/analysis/community.py
@@ -6,7 +6,7 @@ import lib.config as config
 import lib.vis as vis
 
 
-def infomap_igraph(ig_graph, net_file_location=None, reduce_graph=False):
+def infomap_igraph(ig_graph, net_file_location=None):
     """ 
         Performs igraph-infomap analysis on the nx graph
     
@@ -25,9 +25,6 @@ def infomap_igraph(ig_graph, net_file_location=None, reduce_graph=False):
         ig_graph = igraph.Graph()
         ig_graph = igraph.read(net_file_location, format="pajek")
 
-    if reduce_graph:
-        ig_graph = select_top_vertices(ig_graph, "UU")
-
     community = ig_graph.community_infomap(edge_weights=ig_graph.es["weight"])
     codelength = community.codelength
 
@@ -42,49 +39,6 @@ def infomap_igraph(ig_graph, net_file_location=None, reduce_graph=False):
 
     # http://stackoverflow.com/questions/21976889/plotting-communities-with-python-igraph
     return ig_graph, community.membership
-
-
-def select_top_vertices(ig_graph, pajek_type, top_channels=None, top_users=None, top_id_for_channels_and_user_graphs=None, top_id_for_user_graphs=None):
-    """ 
-    Reduces the ig_graph to only include top-nodes
-    
-    Args:
-        ig_graph(object): igraph graph object
-        pajek_type(str): UU/CU/CC
-
-    Returns:
-        ig_graph: updated (reduced) igraph graph object
-    """
-
-    # from reduced hashes, use degree analysis on edglelist to select top-nodes?
-    
-    '''
-    default:
-    top_channels = ["#ubuntu-devel", "#ubuntu-bugs", "#ubuntu", "#ubuntu-irc", "#xubuntu-devel", "#ubuntu-classroom", "#launchpad", "#kubuntu-devel", "#ubuntu-quality", "#ubuntu+1", "#ubuntu-release", "#ubuntu-meeting", "#kubuntu", "#ubuntu-locoteams", "#ubuntu-beginners", "#lubuntu", "#ubuntu-motu", "#ubuntu-discuss", "#ubuntu-on-air", "#xubuntu", "#ubuntu-community-team", "#ubuntu-uk", "#ubuntu-server", "#ubuntu-x", "#ubuntu-ops", "#ubuntu-phone", "#ubuntu-arm", "#ubuntu-kernel", "#ubuntu-desktop", "#ubuntu-unity"]
-    top_users = ["benonsoftware", "ubottu", "jrib", "OerHeks", "dr_willis", "MoL0ToV", "FloodBot1", "cfhowlett", "dkessel", "DJones", "BluesKaj", "iceroot", "usr13", "bekks", "JoseeAntonioR", "Unit193", "kubine", "ubot2", "micahg", "sterna", "zdobersek", "CrazyLemon", "lynxlynxlynx", "czajkowski", "lifeless", "mlankhorst", "penguin42", "brobostigon", "AlanBell", "popey", "SilverSpace", "ubot5", "xiaoy", "cjohnston", "stgraber", "philipballew", "andol", "waltman", "holstein", "len-1304", "Wizard", "ScottK", "snap-l", "rick_h_", "ricotz", "mhall119", "bkerensa", "jcastro", "pleia2", "Scrimmer", "aleksei`", "[Raiden]", "artus", "ubot-it", "xangua", "jussi", "ikonia", "Pici", "Myrtti", "koegs", "hallyn", "davmor2", "roaksoax", "sarnold", "infinity", "mesquka", "wgrant", "tjaalton", "xnox", "lubotu3", "shadeslayer", "Tm_T", "Riddell", "SergioMeneses", "balloons", "ofan", "dobey", "Laney", "cjwatson", "jtaylor", "slangasek", "bdmurray", "tsimpson", "apw", "hazmat", "tumbleweed", "tgm4883", "gnomefreak", "cyphermox", "mgz", "didrocks", "hplc", "lordievader", "jibel", "seb128", "jodh", "ubot2`", "escott", "smartboyhw", "dholbach"]
-    top_id_for_channels_and_user_graphs = ['1000001', '1000003', '1000005', '1000006', '1000007', '1000008', '1000011', '1000012', '1000014', '1000015', '1000017', '1000018', '1000020', '1000021', '1000023', '1000026', '1000027', '1000028', '1000030', '1000031', '1000032', '1000033', '1000034', '1000035', '1000036', '1000044', '1000047', '1000049', '1000050', '1000059', '2', '9', '31', '32', '37', '62', '71', '109', '168', '173', '179', '188', '219', '256', '381', '382', '392', '415', '442', '451', '453', '455', '459', '471', '473', '477', '478', '487', '489', '493', '505', '515', '571', '631', '639', '653', '668', '677', '680', '682', '694', '749', '779', '780', '788', '794', '796', '797', '799', '800', '805', '806', '809', '823', '857', '915', '940', '990', '1273', '1283', '1321', '1324', '1326', '1333', '1343', '1362', '1375', '1386', '1387', '1399', '1418', '1419', '1421', '1425', '1426', '1431', '1531', '1537', '1544', '1546', '1552', '1562', '1564', '1566', '1602', '1681', '1737', '2245', '2334', '2392', '3157', '3186', '4262', '4714', '4774', '4778', '5931', '6286', '8776', '9191']  
-    top_id_for_user_graphs = ['2', '9', '31', '32', '37', '62', '71', '109', '168', '173', '179', '188', '219', '256', '381', '382', '392', '415', '442', '451', '453', '455', '459', '471', '473', '477', '478', '487', '489', '493', '505', '515', '571', '631', '639', '653', '668', '677', '680', '682', '694', '749', '779', '780', '788', '794', '796', '797', '799', '800', '805', '806', '809', '823', '857', '915', '940', '990', '1273', '1283', '1321', '1324', '1326', '1333', '1343', '1362', '1375', '1386', '1387', '1399', '1418', '1419', '1421', '1425', '1426', '1431', '1531', '1537', '1544', '1546', '1552', '1562', '1564', '1566', '1602', '1681', '1737', '2245', '2334', '2392', '3157', '3186', '4262', '4714', '4774', '4778', '5931', '6286', '8776', '9191'] 
-    '''
-    
-    def delete_helper(top_parameter):
-        nodes_to_delete = []
-        for node in ig_graph.vs():
-            if node["id"] not in top_parameter:
-                nodes_to_delete.append(node.index)
-        return nodes_to_delete
-
-    if pajek_type == "CC":
-        nodes_to_delete = delete_helper(top_channels)
-    elif pajek_type == "CU":
-        nodes_to_delete = delete_helper(top_id_for_channels_and_user_graphs) 
-    elif pajek_type == "UU":
-        nodes_to_delete = delete_helper(top_id_for_user_graphs) 
-    else:
-        print "ERROR"
-
-    ig_graph.delete_vertices(nodes_to_delete)
-    
-    return ig_graph
 
 
 def convert_id_name_community(max_hash, community_txt_file, hash_file_txt, reduced_hash_txt, reduced_community):

--- a/lib/analysis/network.py
+++ b/lib/analysis/network.py
@@ -135,17 +135,20 @@ def channel_user_presence_graph_and_csv(nicks, nick_same_list, channels_for_user
         "CC": {
                 "graph": None,
                 "matrix": None,
-                "reducedMatrix": None
+                "reducedMatrix": None,
+                "reducedGraph": None
         },
         "CU": {
                 "graph": None,
                 "matrix": None,
-                "reducedMatrix": None
+                "reducedMatrix": None,
+                "reducedGraph": None
         },
         "UU": {
                 "graph": None,
                 "matrix": None,
-                "reducedMatrix": None
+                "reducedMatrix": None,
+                "reducedGraph": None
         },
     }
 
@@ -319,6 +322,10 @@ def channel_user_presence_graph_and_csv(nicks, nick_same_list, channels_for_user
     temp_channels = np.delete(CC_adjacency_matrix, indices_to_delete_channels, 1) #delete columns
     reduced_CC_adjacency_matrix = np.delete(temp_channels, indices_to_delete_channels, 0) #delete rows
     presence_graph_and_matrix["CC"]["reducedMatrix"] = reduced_CC_adjacency_matrix
+    
+    reduced_CC_graph = channel_channel_graph.copy()
+    reduced_CC_graph.remove_nodes_from(map(str, np.array(indices_to_delete_channels) + config.STARTING_HASH_CHANNEL)) # say the indices to remove are 1,2 presence_graph_and_matrix["CC"]["reducedGraph"] = reduced_CC_graph 
+    
     print "Generated Reduced CC Adjacency Matrix"
 
     #to calculate sum first take the transpose of CU matrix so users in row
@@ -343,6 +350,11 @@ def channel_user_presence_graph_and_csv(nicks, nick_same_list, channels_for_user
     #update the CU matrix by deleting particular columns, and rows which are not in top_indices_users, channels
     temp_user_channel = np.delete(CU_adjacency_matrix, indices_to_delete_users, 1) #delete columns
     reduced_CU_adjacency_matrix = np.delete(temp_user_channel, indices_to_delete_channels, 0) #delete rows
+    
+    reduced_CU_graph = channel_user_graph.copy()
+    reduced_CU_graph.remove_nodes_from(np.array(indices_to_delete_channels) + config.STARTING_HASH_CHANNEL) #remove non top channels_
+    reduced_CU_graph.remove_nodes_from(np.array(indices_to_delete_users)) #remove users
+    presence_graph_and_matrix["CU"]["reducedGraph"] = reduced_CU_graph
 
     print "Generated Reduced CU Adjacency Matrix"
     presence_graph_and_matrix["CU"]["reducedMatrix"] = reduced_CU_adjacency_matrix
@@ -350,6 +362,11 @@ def channel_user_presence_graph_and_csv(nicks, nick_same_list, channels_for_user
     #update the UU matrix by deleting both columns and rows
     temp_users = np.delete(UU_adjacency_matrix, indices_to_delete_users, 1) #delete columns
     reduced_UU_adjacency_matrix = np.delete(temp_users, indices_to_delete_users, 0) #delete rows
+    
+    reduced_UU_graph = user_user_graph.copy()
+    reduced_UU_graph.remove_nodes_from(np.array(indices_to_delete_users))
+    presence_graph_and_matrix["UU"]["reducedGraph"] = reduced_UU_graph
+    
     print "Generated Reduced UU Adjacency Matrix"
     presence_graph_and_matrix["UU"]["reducedMatrix"] = reduced_UU_adjacency_matrix
 


### PR DESCRIPTION
The infomaps_igraph function inside the community.py
should not select the top indices to form reduced graph rather,
this should be called be reduced graph since the preprocessing
to select top users and channels is already done there is no
need to pass full graph and then repeat the reduction work.

This patch modifies the network.py fucntion for co-presence to
return reduced graph as well.

Issue link: https://github.com/prasadtalasila/IRCLogParser/issues/104

## What? Why?
Fix  #104  

Changes proposed in this pull request:
1) don't select top vertices or reduce graph in the infomap_igraph function.
2) rather simply pass the reduced graph that can be already calculated inside network.py, we just need to return it.

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96