### PR TITLE
add dependency installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ To run the tests locally on your machine, run `python -m unittest -v tests` in t
 ## Installation
 
 IRCLogParser depends on various third-party libraries which are handled by [setup.py](./setup.py). 
-Run `pip -v install -e .` in the root directory to install these dependencies.
+Run the "install.sh" script in the root directory to install these dependencies and other OS level
+dependencies for the third-party libraries.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y python-setuptools python-dev build-essential
+easy_install pip
+pip install --upgrade virtualenv
+pip install --upgrade pip			#does not upgrade
+
+# install graphviz, igraph and their python bindings
+apt-get install -y libxml2-dev build-essential
+apt-get install -y libcdt5 libcgraph6 libgd3 libgvc6 libgvpr2 libxaw7 libxmu6 libxt6 fonts-liberation libgraphviz-dev libcgraph6 python-dbg libjs-sphinxdoc
+apt-get install -y graphviz graphviz-dev graphviz-doc python-pygraphviz python-pygraphviz-dbg python-pygraphviz-doc 
+apt-get install -y libigraph0v5 libigraph0-dev
+apt-get install -y python-tk
+apt-get install -y python-scipy
+apt-get install libcairo2-dev
+apt-get install libffi-dev
+pip install cairocffi
+
+# install IRCLogParser
+pip -v install -e .


### PR DESCRIPTION
This patch adds a installation script that
will install all the os dependency required
for python packages used. This script works
only for ubuntu.

## What? Why?
Adds installation script.

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96