### PR TITLE
network: fix degree_analysis_on_graph

### DIFF
--- a/lib/analysis/network.py
+++ b/lib/analysis/network.py
@@ -452,7 +452,7 @@ def degree_analysis_on_graph(nx_graph, date=None, directed = True):
         key_list = ""
         for key in degree_dict:
             if degree_dict[key] == degree:
-                key_list += (key + ", ")
+                key_list += (str(key) + ", ")
         return key_list
 
     degree_map = {} # will map a string(eg "out", "in" , "all") to nx_graph.out_degree() etc


### PR DESCRIPTION
In give_userlist_where_degree_helper, key (integer)
was being appended to string which raises an error.
This patch fixes it by type-castinh key to string.


Changes proposed in this pull request:
typecast key to str before adding string

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96