### PR TITLE
install.sh: download required nltk corpus

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,3 +19,5 @@ pip install cairocffi
 
 # install IRCLogParser
 pip -v install -e .
+# install nltk corpus wordnet
+python -m nltk.downloader wordnet


### PR DESCRIPTION
The nlkt corpus wordnet is being used and needs
to be installed by the script. It cannot be put
inside setup.py since nltk corpus are not library
that can be installed by pip.
This patch adds a line in install shell script
to download the wordnet corpus.

Issue link: https://github.com/prasadtalasila/IRCLogParser/issues/135

## What? Why?
Fix #135 #76 

Changes proposed in this pull request:
Install nltk corpus wordnet in install script since this is a required dependency.

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and po- a
- bst refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96