### PR TITLE
vis: remove X-Server dependency for visualization

### DIFF
--- a/lib/vis.py
+++ b/lib/vis.py
@@ -1,3 +1,5 @@
+import matplotlib as mpl
+mpl.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.optimize import curve_fit


### PR DESCRIPTION
Matplotlib by default uses a backend for plotting
which requires X-Server. This patch forces
matplotlib to use Agg backend which is X-Server
independent. This way the library can be used on
remote server which no $DISPLAY or X-Server.

Reference: https://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server
Issue Link: https://github.com/prasadtalasila/IRCLogParser/issues/102

## What? Why?
Fix #102 

Changes proposed in this pull request:
Force matplotlib to use Agg (a non X-Server dependent) backend.

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96