### PR TITLE
save arc_graphs in output_directory

### DIFF
--- a/lib/in_out/saver.py
+++ b/lib/in_out/saver.py
@@ -7,6 +7,7 @@ from networkx.readwrite import json_graph
 import json
 sys.path.append('../lib')
 import lib.config as config
+from shutil import copy2
 
 def check_if_dir_exists(output_directory):
     """ 
@@ -110,6 +111,10 @@ def save_js_arc(reduced_CC_graph, channels_hash, output_directory, output_file_n
        null
         
     """
+    check_if_dir_exists(output_directory) #create output directory if doesn't exist
+    copy2("../protovis/" + "arc_graph.html", output_directory) #copy required files to output_directory
+    copy2("../protovis/" + "ex.css", output_directory)
+    copy2("../protovis/" + "protovis-r3.2.js", output_directory)
     jsondict = json_graph.node_link_data(reduced_CC_graph)
     max_weight_val = max(item['weight'] for item in jsondict['links'])
     # the key names in the jsondict_top_channels are kept as the following so that index.html can render it

--- a/ubuntu.py
+++ b/ubuntu.py
@@ -73,7 +73,7 @@ log_data = reader.linux_input(log_directory, ["ALL"], starting_date, ending_date
 nicks, nick_same_list, channels_for_user, nick_channel_dict, nicks_hash, channels_hash = nickTracker.nick_tracker(log_data, True)
 dict_out, graph = network.channel_user_presence_graph_and_csv(nicks, nick_same_list, channels_for_user, nick_channel_dict, nicks_hash, channels_hash)
 
-saver.save_js_arc(dict_out["CC"]["reducedGraph"], channels_hash, "lib/protovis/", "cc.js")
+saver.save_js_arc(dict_out["CC"]["reducedGraph"], channels_hash, config.OUTPUT_DIRECTORY + "protovis/", "cc.js")
 
 for ptype in presence_type:
     saver.save_csv(dict_out[ptype]["reducedMatrix"],output_directory, "r"+ptype)
@@ -85,6 +85,7 @@ for ptype in presence_type:
     vis.plot_infomap_igraph(adj_graph, adj_membership, output_directory, "adj"+ptype+"_infomaps-full")
 
 degree_anal_message_number_CC = network.degree_analysis_on_graph(dict_out["CC"]["graph"], directed=False)
+
 saver.save_csv(degree_anal_message_number_CC["degree"]["formatted_for_csv"], output_directory, "CC_degree")
 degree_anal_message_number_UU = network.degree_analysis_on_graph(dict_out["UU"]["graph"], directed = False)
 saver.save_csv(degree_anal_message_number_UU["degree"]["formatted_for_csv"], output_directory, "UU_degree")


### PR DESCRIPTION
Currently the generated arc graph is being
stored in lib/protovis. This commit modifies
the saving of arc_graph to output_directory.

Issue link: https://github.com/prasadtalasila/IRCLogParser/issues/152

## What? Why?
Fix #152 

Changes proposed in this pull request:
- store arc graph in OUTPUT_DIRECTORY

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96