### PR TITLE
Channel-User: truncate values below threshold in log_plots

### DIFF
--- a/ubuntu.py
+++ b/ubuntu.py
@@ -103,7 +103,13 @@ saver.save_csv(degree_anal_message_number_CU["degree"]["formatted_for_csv"], out
 slope,intercept,r_square,mse = vis.generate_log_plots(degree_anal_message_number_CC["degree"]["raw_for_vis"], output_directory, "CC_degree_curve_fit")
 saver.save_csv( [["Y","K","R^2", "MSE"], [slope,intercept,r_square,mse]], output_directory,"CC-degree-curve-fit")
 
-slope,intercept,r_square,mse = vis.generate_log_plots(degree_anal_message_number_CU["degree"]["raw_for_vis"], output_directory, "CU_degre_curve_fit")
+Y = degree_anal_message_number_CU["degree"]["raw_for_vis"][1:]
+data = [(i, Y[i]) for i in range(len(Y))]
+
+CU_truncated, cutoff = channel.truncate_table(data, 0.5)
+CU_T = [ data[1] for data in list(CU_truncated)]
+
+slope,intercept,r_square,mse = vis.generate_log_plots(CU_T, output_directory, "CU_degre_curve_fit")
 saver.save_csv( [["Y","K","R^2", "MSE"], [slope,intercept,r_square,mse]], output_directory,"CU-degree-curve-fit")
 
 slope,intercept,r_square,mse = vis.generate_log_plots(degree_anal_message_number_UU["degree"]["raw_for_vis"], output_directory, "UU_degree_curve_fit")


### PR DESCRIPTION
As observed after certain point the log_plot
is insignificant and hence the linear fit
we get is not useful. To fix this, the commit
truncates the degree analysis on CU matrix using
a certain cut-off of 10.
Issue Link: https://github.com/prasadtalasila/IRCLogParser/issues/153

## What? Why?
Fix #153 

Changes proposed in this pull request:
- truncate degree analysis on CU.
- cutoff 10%

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96