### PR TITLE
ubuntu.py: update script for different cutoff percentiles

### DIFF
--- a/lib/in_out/saver.py
+++ b/lib/in_out/saver.py
@@ -113,9 +113,9 @@ def save_js_arc(reduced_CC_graph, channels_hash, output_directory, output_file_n
         
     """
     check_if_dir_exists(output_directory) #create output directory if doesn't exist
-    copy2("../protovis/" + "arc_graph.html", output_directory) #copy required files to output_directory
-    copy2("../protovis/" + "ex.css", output_directory)
-    copy2("../protovis/" + "protovis-r3.2.js", output_directory)
+    copy2("./lib/protovis/" + "arc_graph.html", output_directory) #copy required files to output_directory
+    copy2("./lib/protovis/" + "ex.css", output_directory)
+    copy2("./lib/protovis/" + "protovis-r3.2.js", output_directory)
     jsondict = json_graph.node_link_data(reduced_CC_graph)
     max_weight_val = max(item['weight'] for item in jsondict['links'])
     # the key names in the jsondict_top_channels are kept as the following so that index.html can render it


### PR DESCRIPTION
This commit update the script to run for different cut-off
percentiles to generate conversation characteristics.
Also it update saver_js to fix the location of protovis
folder.

Issue Link: https://github.com/prasadtalasila/IRCLogParser/issues/165

## What? Why?
Fix #165 

Changes proposed in this pull request:
- Update script to run for different cutoff percentiles.

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96