### PR TITLE
fix stdout redirection

### DIFF
--- a/test/unit-test/test_lib/test_analysis/test_network.py
+++ b/test/unit-test/test_lib/test_analysis/test_network.py
@@ -52,6 +52,7 @@ class NetworkTest(unittest.TestCase):
         ret = network.message_number_graph(self.log_data, self.nicks, self.nick_same_list, DAY_BY_DAY_ANALYSIS=False)
         
         sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         mock_util.to_graph.assert_called_once_with(self.nick_same_list)
         mock_util.create_connected_nick_list.assert_called_once_with(conn_list)
@@ -83,6 +84,7 @@ class NetworkTest(unittest.TestCase):
         dict_out,graph = network.channel_user_presence_graph_and_csv(nicks, nick_same_list, channels_for_user, nick_channel_dict, nicks_hash, channels_hash)
         
         sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertTrue(nx.is_isomorphic(expected_graph, graph))
         self.assertTrue(nx.is_isomorphic(expected_dict_out['CC']['graph'], dict_out['CC']['graph']))
@@ -108,6 +110,7 @@ class NetworkTest(unittest.TestCase):
         f = open(current_directory +'/data/filter_edge_list_out.txt','r')
         expected_output = f.read()
         f.close()
+        capturedOutput.close()
         
         self.assertEqual(output, expected_output)
 
@@ -118,8 +121,14 @@ class NetworkTest(unittest.TestCase):
         directed_deg_analysis_expected = util.load_from_disk(current_directory + '/data/directed_deg_analysis_result')
         undirected_deg_analysis_expected = util.load_from_disk(current_directory + '/data/undirected_deg_anlaysis_result')
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         directed_deg_analysis = network.degree_analysis_on_graph(directed_graph, directed=True)
         undirected_deg_analysis = network.degree_analysis_on_graph(undirected_graph, directed=False)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(directed_deg_analysis, directed_deg_analysis_expected)
         self.assertEqual(undirected_deg_analysis, undirected_deg_analysis_expected)
@@ -142,7 +151,13 @@ class NetworkTest(unittest.TestCase):
         mock_util.get_year_month_day.side_effect = util.load_from_disk(current_directory + "/data/message_time_graph/get_year_month_day")
         mock_util.build_graphs.side_effect = util.load_from_disk(current_directory + "/data/message_time_graph/build_graphs")
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         ret = network.message_time_graph(self.log_data, self.nicks, self.nick_same_list, DAY_BY_DAY_ANALYSIS=False)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         mock_util.to_graph.assert_called_once_with(self.nick_same_list)
         mock_util.create_connected_nick_list.assert_called_once_with(conn_list)
@@ -162,7 +177,13 @@ class NetworkTest(unittest.TestCase):
         bin_matrix_ = util.load_from_disk(current_directory + "/data/message_number_bins_csv/bin_matrix")
         tot_msgs_ = util.load_from_disk(current_directory + "/data/message_number_bins_csv/tot_msgs")
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         bin_matrix, tot_msgs = network.message_number_bins_csv(self.log_data, self.nicks, self.nick_same_list)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(bin_matrix, bin_matrix_)
         self.assertEqual(tot_msgs, tot_msgs_)
@@ -178,7 +199,13 @@ class NetworkTest(unittest.TestCase):
         
         mock_msg_graph.return_value = msg_num_graph_day_list
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         out_degree, in_degree, total_degree = network.degree_node_number_csv(self.log_data, self.nicks, self.nick_same_list)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(out_degree, out_degree_)
         self.assertEqual(in_degree, in_degree_)
@@ -222,6 +249,7 @@ class NetworkTest(unittest.TestCase):
         message_num_graph, top_hub, top_keyword_overlap, top_auth = network.identify_hubs_and_experts(self.log_data, self.nicks, self.nick_same_list)
         
         sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(top_hub, top_hub_)
         self.assertEqual(top_keyword_overlap, top_keyword_overlap_)

--- a/test/unit-test/test_lib/test_analysis/test_user.py
+++ b/test/unit-test/test_lib/test_analysis/test_user.py
@@ -121,8 +121,9 @@ class UserTest(unittest.TestCase):
         captured_output = StringIO.StringIO()
         sys.stdout = captured_output
         user.keywords_clusters(self.log_data, self.nicks, self.nick_same_list, current_directory + "/data/user_test/","temp_output_keywords_clusters")
-        sys.stdout = sys.__stdin__
+        sys.stdout = sys.__stdout__
         output = captured_output.getvalue()
+        captured_output.close()
 
         self.assertEqual(expected_captured_output, output)
         self.assertTrue(filecmp.cmp(current_directory + "/data/user_test/output_keywords_clusters.txt", current_directory + "/data/user_test/temp_output_keywords_clusters.txt"))

--- a/test/unit-test/test_lib/test_in_out/test_reader.py
+++ b/test/unit-test/test_lib/test_in_out/test_reader.py
@@ -2,7 +2,8 @@ import unittest
 import lib.in_out.reader as reader
 import lib.util as util
 import lib.config as config
-import os
+import os, sys
+import StringIO
 
 current_directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -23,7 +24,17 @@ class ReaderTest(unittest.TestCase):
     def test_nick_tracker(self):
         log_data = reader.linux_input(current_directory + "/data/log/", self.channel_name, self.starting_date, self.ending_date)
         
-        assert log_data == self.log_data
+        self.assertEqual(log_data, self.log_data)
+        
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
+        reader.linux_input("some non existent path/", self.channel_name, self.starting_date, self.starting_date)
+        output = capturedOutput.getvalue()
+        self.assertEqual(output, "[Error | io/linuxInput] Path some non existent path/2013/01/01/ doesn't exist\n")
+          
+        capturedOutput.close()
+        sys.stdout = sys.__stdout__
         
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit-test/test_slack/test_in_out/test_reader.py
+++ b/test/unit-test/test_slack/test_in_out/test_reader.py
@@ -2,7 +2,8 @@ import unittest
 import lib.slack.in_out.reader as reader
 import lib.slack.util as util
 import lib.slack.config as config
-import os
+import os, sys
+import StringIO
 
 current_directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -22,7 +23,17 @@ class ReaderTest(unittest.TestCase):
     def test_nick_tracker(self):
         log_data = reader.linux_input_slack(current_directory + "/data/slackware/", self.starting_date, self.ending_date)
         
-        assert log_data == self.log_data
+        self.assertEqual(log_data, self.log_data)
+        
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
+        reader.linux_input_slack("some non existent path/", self.starting_date, self.starting_date)
+        output = capturedOutput.getvalue()
+        self.assertEqual(output, "[Error | io/linuxInput] Path some non existent path/2013/ doesn't exist\n")
+           
+        capturedOutput.close()
+        sys.stdout = sys.__stdout__
         
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit-test/test_slack/test_lib/test_analysis/test_network.py
+++ b/test/unit-test/test_slack/test_lib/test_analysis/test_network.py
@@ -50,6 +50,7 @@ class NetworkTest(unittest.TestCase):
         ret = network.message_number_graph(self.log_data, self.nicks, self.nick_same_list, DAY_BY_DAY_ANALYSIS=False)
         
         sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertFalse(nx.is_isomorphic(ret, util.load_from_disk(current_directory + "/data/message_number_graph/aggregate_message_number_graph")))
         mock_util.to_graph.assert_called_once_with(self.nick_same_list)
@@ -64,6 +65,7 @@ class NetworkTest(unittest.TestCase):
         f = open(current_directory +'/data/filter_edge_list_out.txt','r')
         expected_output = f.read()
         f.close()
+        capturedOutput.close()
         
         self.assertEqual(output, expected_output)
         
@@ -71,7 +73,13 @@ class NetworkTest(unittest.TestCase):
         directed_graph = util.load_from_disk(current_directory + '/data/directed_graph')
         directed_deg_analysis_expected = util.load_from_disk(current_directory + '/data/directed_deg_analysis_result')
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         directed_deg_analysis = network.degree_analysis_on_graph(directed_graph, directed=True)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(directed_deg_analysis, directed_deg_analysis_expected)
     
@@ -93,7 +101,13 @@ class NetworkTest(unittest.TestCase):
         mock_util.get_year_month_day.side_effect = util.load_from_disk(current_directory + "/data/message_time_graph/get_year_month_day")
         mock_util.build_graphs.side_effect = util.load_from_disk(current_directory + "/data/message_time_graph/build_graphs")
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         ret = network.message_time_graph(self.log_data, self.nicks, self.nick_same_list, DAY_BY_DAY_ANALYSIS=False)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         mock_util.to_graph.assert_called_once_with(self.nick_same_list)
         mock_util.create_connected_nick_list.assert_called_once_with(conn_list)
@@ -112,7 +126,13 @@ class NetworkTest(unittest.TestCase):
         bin_matrix_ = util.load_from_disk(current_directory + "/data/message_number_bins_csv/bin_matrix")
         tot_msgs_ = util.load_from_disk(current_directory + "/data/message_number_bins_csv/tot_msgs")
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         bin_matrix, tot_msgs = network.message_number_bins_csv(self.log_data, self.nicks, self.nick_same_list)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(bin_matrix, bin_matrix_)
         self.assertEqual(tot_msgs, tot_msgs_)
@@ -127,7 +147,13 @@ class NetworkTest(unittest.TestCase):
         
         mock_msg_graph.return_value = msg_num_graph_day_list
         
+        capturedOutput = StringIO.StringIO()
+        sys.stdout = capturedOutput
+        
         out_degree, in_degree, total_degree = network.degree_node_number_csv(self.log_data, self.nicks, self.nick_same_list)
+        
+        sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         mock_msg_graph.assert_called_once_with(self.log_data, self.nicks, self. nick_same_list, True)
         self.assertEqual(out_degree, out_degree_)
@@ -166,6 +192,7 @@ class NetworkTest(unittest.TestCase):
         message_num_graph, top_hub, top_keyword_overlap, top_auth = network.identify_hubs_and_experts(self.log_data, self.nicks, self.nick_same_list)
         
         sys.stdout = sys.__stdout__
+        capturedOutput.close()
         
         self.assertEqual(top_hub, top_hub_)
         self.assertEqual(top_keyword_overlap, top_keyword_overlap_)


### PR DESCRIPTION
Changes proposed in this pull request:
- mute remaining test function for print statements
- fix wrong reset of stdout in test_user.py
- fix memory leak by closing capturedOutput
- imporve unit-test for reader.py to test scenarios when wrong 
log directory is provided as input

## Checks
- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@rohangoel96