### PR TITLE
channel: remove PERCENTILE cutoff strategy

### DIFF
--- a/lib/analysis/channel.py
+++ b/lib/analysis/channel.py
@@ -316,11 +316,6 @@ def response_time(log_dict, nicks, nick_same_list, cutoff_percentile):
 			rt_cutoff_time_frac = numpy.mean(resp_frequency) + 2*numpy.std(resp_frequency)
 			rt_cutoff_time = int(numpy.ceil(rt_cutoff_time_frac))
 
-		elif config.CUTOFF_TIME_STRATEGY == "PERCENTILE":
-			# nothing further to do; truncate_table() already gives rt_cutoff_time
-			# based on percentile
-			pass
-
 	
 	return truncated_rt, rt_cutoff_time
 

--- a/lib/slack/analysis/channel.py
+++ b/lib/slack/analysis/channel.py
@@ -316,12 +316,7 @@ def response_time(log_dict, nicks, nick_same_list, cutoff_percentile):
 			rt_cutoff_time_frac = numpy.mean(resp_frequency) + 2*numpy.std(resp_frequency)
 			rt_cutoff_time = int(numpy.ceil(rt_cutoff_time_frac))
 
-		elif config.CUTOFF_TIME_STRATEGY == "PERCENTILE":
-			# nothing further to do; truncate_table() already gives rt_cutoff_time
-			# based on percentile
-			pass
 
-	
 	return truncated_rt, rt_cutoff_time
 
 


### PR DESCRIPTION
## Remove PERCENTILE cutoff strategy
Fix #257  . (Add Reference to the issue if any)

Changes proposed in this pull request:
- Remove PERCENTILE cutoff strategy from slack/analysis/channel.py and lib/analysis/channel.py
## Checks
- [X] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure you have added required documentation
- [ ] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@kaushik-rohit
@prasadtalasila