### PR TITLE
fix failing travis build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'pandas',
         'python-igraph',
         'nltk',
-        'plotly',
+        'plotly==2.4.1',
         'ddt',
         'mock'
         


### PR DESCRIPTION
Travis build is failing because of the latest release
of plotly which is broken. The solution is to install
the latest stable version of plotly which is v1.35.0

## What? Why?
fix failing travis build

Changes proposed in this pull request:
- install plotly v1.35.0 which is the latest stable version

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@kaushik-rohit
@prasadtalasila
