### PR TITLE
fix install error

### DIFF
--- a/script/install
+++ b/script/install
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y python-setuptools python-dev build-essential python-pip
-easy_install pip
+apt-get install -y python-setuptools python-dev build-essential
+pip install -U pip
 pip install --upgrade virtualenv
-pip install --upgrade pip			#does not upgrade
 
 # install graphviz, igraph and their python bindings
 apt-get install -y libxml2-dev build-essential


### PR DESCRIPTION
## What? Why?
Fix install script error. (igraph plotting not available)

Changes proposed in this pull request:
- use get-pip.py to install pip instead of using easy_install

##Testing(briefly mention the tests you wrote in regard to the proposed changes)
- [ ] Characteristics of the input used for test (eg: logs duration, graph size, array size)
- [ ] Characteristics of the output used for test.

## Checks
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure you have added required documentation
- [x] If you have refactored a code, make sure that you have compared the outputs pre and post refactoring. Add both pre and post refaoring screenshots below if the output is visual

## Any images?

## Notify reviewers
@kaushik-rohit
@prasadtalasila
